### PR TITLE
Restore Google Analytics consent integration

### DIFF
--- a/site-assets/javascripts/analytics-consent.js
+++ b/site-assets/javascripts/analytics-consent.js
@@ -1,0 +1,261 @@
+(function () {
+  var MEASUREMENT_ID = "G-ZJ5FMB5HRM";
+  var CONSENT_KEY = "circuswiki:analytics-consent";
+  var GA_SCRIPT_ID = "cw-google-analytics";
+  var SETTINGS_ID = "cw-analytics-settings";
+  var BANNER_ID = "cw-analytics-consent";
+  var loaded = false;
+
+  var TEXT = {
+    de: {
+      title: "Cookie-Einstellungen",
+      description:
+        "Wir nutzen Google Analytics nur mit deiner Zustimmung, um zu verstehen, welche Seiten hilfreich sind und wie CircusWiki verbessert werden kann.",
+      accept: "Akzeptieren",
+      decline: "Ablehnen",
+      change: "Cookie-Einstellungen ändern",
+      accepted: "Analytics ist aktuell aktiviert.",
+      declined: "Analytics ist aktuell deaktiviert.",
+    },
+    en: {
+      title: "Cookie settings",
+      description:
+        "We use Google Analytics only with your consent to understand which pages are useful and how CircusWiki can be improved.",
+      accept: "Accept",
+      decline: "Decline",
+      change: "Change cookie settings",
+      accepted: "Analytics is currently enabled.",
+      declined: "Analytics is currently disabled.",
+    },
+  };
+
+  function language() {
+    var lang = (document.documentElement.getAttribute("lang") || navigator.language || "en").toLowerCase();
+    return lang.indexOf("de") === 0 ? "de" : "en";
+  }
+
+  function messages() {
+    return TEXT[language()] || TEXT.en;
+  }
+
+  function storedConsent() {
+    try {
+      return window.localStorage.getItem(CONSENT_KEY);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function storeConsent(value) {
+    try {
+      window.localStorage.setItem(CONSENT_KEY, value);
+    } catch (error) {
+      // Consent still applies for this page if storage is unavailable.
+    }
+  }
+
+  function currentPath() {
+    return window.location.pathname + window.location.search + window.location.hash;
+  }
+
+  function sendPageView() {
+    if (!loaded || typeof window.gtag !== "function") {
+      return;
+    }
+
+    window.gtag("event", "page_view", {
+      page_title: document.title,
+      page_location: window.location.href,
+      page_path: currentPath(),
+    });
+  }
+
+  function loadAnalytics() {
+    if (loaded || document.getElementById(GA_SCRIPT_ID)) {
+      loaded = true;
+      sendPageView();
+      return;
+    }
+
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = function () {
+      window.dataLayer.push(arguments);
+    };
+    window.gtag("js", new Date());
+    window.gtag("config", MEASUREMENT_ID, { send_page_view: false });
+
+    var script = document.createElement("script");
+    script.id = GA_SCRIPT_ID;
+    script.async = true;
+    script.src = "https://www.googletagmanager.com/gtag/js?id=" + encodeURIComponent(MEASUREMENT_ID);
+    script.addEventListener("load", function () {
+      loaded = true;
+      sendPageView();
+    });
+    document.head.appendChild(script);
+  }
+
+  function expireCookie(name, domain, path) {
+    document.cookie =
+      name +
+      "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=" +
+      path +
+      (domain ? "; domain=" + domain : "") +
+      "; SameSite=Lax";
+  }
+
+  function deleteAnalyticsCookies() {
+    var names = ["_ga", "_gid", "_gat", "_gat_gtag_" + MEASUREMENT_ID.replace(/-/g, "_")];
+    var hostname = window.location.hostname;
+    var domains = ["", hostname, "." + hostname];
+    var paths = ["/", window.location.pathname.replace(/[^/]*$/, "") || "/"];
+
+    names.forEach(function (name) {
+      domains.forEach(function (domain) {
+        paths.forEach(function (path) {
+          expireCookie(name, domain, path);
+        });
+      });
+    });
+  }
+
+  function removeBanner() {
+    var existing = document.getElementById(BANNER_ID);
+    if (existing) {
+      existing.remove();
+    }
+  }
+
+  function setConsent(value) {
+    storeConsent(value);
+    removeBanner();
+    updateSettingsLink();
+
+    if (value === "accepted") {
+      loadAnalytics();
+    } else {
+      deleteAnalyticsCookies();
+    }
+  }
+
+  function button(label, className, value) {
+    var element = document.createElement("button");
+    element.type = "button";
+    element.className = className;
+    element.textContent = label;
+    element.addEventListener("click", function () {
+      setConsent(value);
+    });
+    return element;
+  }
+
+  function showBanner(force) {
+    if (!force && storedConsent()) {
+      return;
+    }
+
+    removeBanner();
+
+    var text = messages();
+    var banner = document.createElement("section");
+    banner.id = BANNER_ID;
+    banner.className = "cw-analytics-consent";
+    banner.setAttribute("aria-labelledby", BANNER_ID + "-title");
+    banner.innerHTML = [
+      '<div class="cw-analytics-consent__body">',
+      '<h2 id="' + BANNER_ID + '-title">' + text.title + "</h2>",
+      "<p>" + text.description + "</p>",
+      "</div>",
+      '<div class="cw-analytics-consent__actions"></div>',
+    ].join("");
+
+    var actions = banner.querySelector(".cw-analytics-consent__actions");
+    actions.appendChild(button(text.decline, "cw-analytics-consent__button cw-analytics-consent__button--secondary", "declined"));
+    actions.appendChild(button(text.accept, "cw-analytics-consent__button cw-analytics-consent__button--primary", "accepted"));
+    document.body.appendChild(banner);
+  }
+
+  function updateSettingsLink() {
+    var link = document.getElementById(SETTINGS_ID);
+    if (!link) {
+      return;
+    }
+
+    var text = messages();
+    var consent = storedConsent();
+    link.textContent = text.change;
+    link.title = consent === "accepted" ? text.accepted : text.declined;
+  }
+
+  function ensureSettingsLink() {
+    if (document.getElementById(SETTINGS_ID)) {
+      updateSettingsLink();
+      return;
+    }
+
+    var text = messages();
+    var footer = document.querySelector(".md-footer-meta__inner, .md-footer, footer") || document.body;
+    var link = document.createElement("button");
+    link.id = SETTINGS_ID;
+    link.type = "button";
+    link.className = "cw-analytics-settings";
+    link.textContent = text.change;
+    link.addEventListener("click", function () {
+      showBanner(true);
+    });
+
+    footer.appendChild(link);
+    updateSettingsLink();
+  }
+
+  function installNavigationTracking() {
+    if (window.document$ && typeof window.document$.subscribe === "function") {
+      window.document$.subscribe(function () {
+        if (storedConsent() === "accepted") {
+          sendPageView();
+        }
+        ensureSettingsLink();
+      });
+      return;
+    }
+
+    ["pushState", "replaceState"].forEach(function (method) {
+      var original = window.history[method];
+      if (typeof original !== "function") {
+        return;
+      }
+      window.history[method] = function () {
+        var result = original.apply(this, arguments);
+        if (storedConsent() === "accepted") {
+          window.setTimeout(sendPageView, 0);
+        }
+        return result;
+      };
+    });
+
+    window.addEventListener("popstate", function () {
+      if (storedConsent() === "accepted") {
+        window.setTimeout(sendPageView, 0);
+      }
+    });
+  }
+
+  function init() {
+    ensureSettingsLink();
+    installNavigationTracking();
+
+    if (storedConsent() === "accepted") {
+      loadAnalytics();
+    } else if (!storedConsent()) {
+      showBanner(false);
+    } else {
+      deleteAnalyticsCookies();
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/site-assets/javascripts/analytics-consent.js
+++ b/site-assets/javascripts/analytics-consent.js
@@ -5,6 +5,7 @@
   var SETTINGS_ID = "cw-analytics-settings";
   var BANNER_ID = "cw-analytics-consent";
   var loaded = false;
+  var memoryConsent = null;
 
   var TEXT = {
     de: {
@@ -40,13 +41,15 @@
 
   function storedConsent() {
     try {
-      return window.localStorage.getItem(CONSENT_KEY);
+      memoryConsent = window.localStorage.getItem(CONSENT_KEY);
+      return memoryConsent;
     } catch (error) {
-      return null;
+      return memoryConsent;
     }
   }
 
   function storeConsent(value) {
+    memoryConsent = value;
     try {
       window.localStorage.setItem(CONSENT_KEY, value);
     } catch (error) {
@@ -59,7 +62,7 @@
   }
 
   function sendPageView() {
-    if (!loaded || typeof window.gtag !== "function") {
+    if (!loaded || storedConsent() !== "accepted" || typeof window.gtag !== "function") {
       return;
     }
 
@@ -71,8 +74,15 @@
   }
 
   function loadAnalytics() {
+    window["ga-disable-" + MEASUREMENT_ID] = false;
+
     if (loaded || document.getElementById(GA_SCRIPT_ID)) {
       loaded = true;
+      if (typeof window.gtag === "function") {
+        window.gtag("consent", "update", {
+          analytics_storage: "granted",
+        });
+      }
       sendPageView();
       return;
     }
@@ -82,6 +92,9 @@
       window.dataLayer.push(arguments);
     };
     window.gtag("js", new Date());
+    window.gtag("consent", "default", {
+      analytics_storage: "granted",
+    });
     window.gtag("config", MEASUREMENT_ID, { send_page_view: false });
 
     var script = document.createElement("script");
@@ -105,7 +118,8 @@
   }
 
   function deleteAnalyticsCookies() {
-    var names = ["_ga", "_gid", "_gat", "_gat_gtag_" + MEASUREMENT_ID.replace(/-/g, "_")];
+    var normalizedId = MEASUREMENT_ID.replace(/-/g, "_");
+    var names = ["_ga", "_ga_" + normalizedId, "_gid", "_gat", "_gat_gtag_" + normalizedId];
     var hostname = window.location.hostname;
     var domains = ["", hostname, "." + hostname];
     var paths = ["/", window.location.pathname.replace(/[^/]*$/, "") || "/"];
@@ -117,6 +131,16 @@
         });
       });
     });
+  }
+
+  function disableAnalytics() {
+    window["ga-disable-" + MEASUREMENT_ID] = true;
+    if (typeof window.gtag === "function") {
+      window.gtag("consent", "update", {
+        analytics_storage: "denied",
+      });
+    }
+    deleteAnalyticsCookies();
   }
 
   function removeBanner() {
@@ -134,7 +158,7 @@
     if (value === "accepted") {
       loadAnalytics();
     } else {
-      deleteAnalyticsCookies();
+      disableAnalytics();
     }
   }
 
@@ -161,17 +185,26 @@
     banner.id = BANNER_ID;
     banner.className = "cw-analytics-consent";
     banner.setAttribute("aria-labelledby", BANNER_ID + "-title");
-    banner.innerHTML = [
-      '<div class="cw-analytics-consent__body">',
-      '<h2 id="' + BANNER_ID + '-title">' + text.title + "</h2>",
-      "<p>" + text.description + "</p>",
-      "</div>",
-      '<div class="cw-analytics-consent__actions"></div>',
-    ].join("");
 
-    var actions = banner.querySelector(".cw-analytics-consent__actions");
+    var body = document.createElement("div");
+    body.className = "cw-analytics-consent__body";
+
+    var title = document.createElement("h2");
+    title.id = BANNER_ID + "-title";
+    title.textContent = text.title;
+
+    var description = document.createElement("p");
+    description.textContent = text.description;
+
+    var actions = document.createElement("div");
+    actions.className = "cw-analytics-consent__actions";
+
+    body.appendChild(title);
+    body.appendChild(description);
     actions.appendChild(button(text.decline, "cw-analytics-consent__button cw-analytics-consent__button--secondary", "declined"));
     actions.appendChild(button(text.accept, "cw-analytics-consent__button cw-analytics-consent__button--primary", "accepted"));
+    banner.appendChild(body);
+    banner.appendChild(actions);
     document.body.appendChild(banner);
   }
 
@@ -249,7 +282,7 @@
     } else if (!storedConsent()) {
       showBanner(false);
     } else {
-      deleteAnalyticsCookies();
+      disableAnalytics();
     }
   }
 

--- a/site-assets/stylesheets/circuswiki.css
+++ b/site-assets/stylesheets/circuswiki.css
@@ -891,3 +891,94 @@ body.circuswiki-hero .md-content__inner > h2 {
     width: 100%;
   }
 }
+
+.cw-analytics-consent {
+  position: fixed;
+  right: clamp(0.75rem, 3vw, 1.4rem);
+  bottom: clamp(0.75rem, 3vw, 1.4rem);
+  z-index: 20;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  width: min(42rem, calc(100vw - 1.5rem));
+  padding: 1rem;
+  border: 1px solid var(--cw-line);
+  border-radius: 1rem;
+  background: var(--cw-panel-solid);
+  box-shadow: 0 1.2rem 3rem rgba(30, 38, 33, 0.22);
+  color: var(--cw-ink);
+}
+
+.cw-analytics-consent__body h2 {
+  margin: 0 0 0.3rem;
+  color: var(--cw-ink);
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.cw-analytics-consent__body p {
+  margin: 0;
+  color: var(--cw-muted);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.cw-analytics-consent__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.cw-analytics-consent__button,
+.cw-analytics-settings {
+  border: 1px solid var(--cw-line);
+  border-radius: 999px;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.cw-analytics-consent__button {
+  padding: 0.46rem 0.75rem;
+}
+
+.cw-analytics-consent__button--primary {
+  border-color: var(--cw-success);
+  background: var(--cw-success);
+  color: var(--cw-paper);
+}
+
+.cw-analytics-consent__button--secondary {
+  background: transparent;
+  color: var(--cw-muted);
+}
+
+.cw-analytics-settings {
+  margin: 0.45rem 0 0.45rem 0.75rem;
+  padding: 0.32rem 0.62rem;
+  background: transparent;
+  color: inherit;
+}
+
+.cw-analytics-consent__button:focus-visible,
+.cw-analytics-settings:focus-visible {
+  outline: 0.16rem solid var(--cw-focus);
+  outline-offset: 0.15rem;
+}
+
+@media (max-width: 44rem) {
+  .cw-analytics-consent {
+    grid-template-columns: 1fr;
+  }
+
+  .cw-analytics-consent__actions {
+    justify-content: stretch;
+  }
+
+  .cw-analytics-consent__button {
+    flex: 1 1 8rem;
+  }
+}

--- a/zensical.cs.toml
+++ b/zensical.cs.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/cs"
 site_dir = "site/cs"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Domů" = "index.md" },

--- a/zensical.el.toml
+++ b/zensical.el.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/el"
 site_dir = "site/el"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Αρχική" = "index.md" },

--- a/zensical.en.toml
+++ b/zensical.en.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/en"
 site_dir = "site/en"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Home" = "index.md" },

--- a/zensical.es.toml
+++ b/zensical.es.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/es"
 site_dir = "site/es"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Inicio" = "index.md" },

--- a/zensical.hu.toml
+++ b/zensical.hu.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/hu"
 site_dir = "site/hu"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Főoldal" = "index.md" },

--- a/zensical.it.toml
+++ b/zensical.it.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/it"
 site_dir = "site/it"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Home" = "index.md" },

--- a/zensical.nl.toml
+++ b/zensical.nl.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/nl"
 site_dir = "site/nl"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Home" = "index.md" },

--- a/zensical.pl.toml
+++ b/zensical.pl.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/pl"
 site_dir = "site/pl"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Strona główna" = "index.md" },

--- a/zensical.pt.toml
+++ b/zensical.pt.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/pt"
 site_dir = "site/pt"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Início" = "index.md" },

--- a/zensical.sk.toml
+++ b/zensical.sk.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/sk"
 site_dir = "site/sk"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Domov" = "index.md" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/de"
 site_dir = "site"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Home" = "index.md" },

--- a/zensical.uk.toml
+++ b/zensical.uk.toml
@@ -9,7 +9,7 @@ repo_name = "nica-ev/circuswiki"
 docs_dir = ".build/uk"
 site_dir = "site/uk"
 extra_css = ["stylesheets/circuswiki.css"]
-extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js"]
+extra_javascript = ["javascripts/site-theme.js", "javascripts/table-sorter.js", "javascripts/language-switcher.js", "javascripts/translation-status.js", "javascripts/analytics-consent.js"]
 
 nav = [
   { "Головна" = "index.md" },


### PR DESCRIPTION
## Summary
- add a Zensical-era analytics consent script using the historical GA4 measurement ID
- load Google Analytics only after explicit consent and add a footer settings control
- wire the shared consent script into all language configs and style the banner

## Validation
- python tools/sync_configs.py
- powershell -ExecutionPolicy Bypass -File tools/check.ps1
- powershell -ExecutionPolicy Bypass -File tools/build_multilang.ps1